### PR TITLE
Create Jmc-104-site performance

### DIFF
--- a/Jmc-104-site performance
+++ b/Jmc-104-site performance
@@ -1,0 +1,6 @@
+//src = "url";
+//url = "https://www.googletagmanager.com/gtm.js?id=GTM-KB7ZZ5L";
+//noop_ = "lodash/noop";
+//union, Result = "@wix/wix-code-server";
+//matchAny = "@wix/wix-code=client";
+//filterByReportToHandlers = "./filterByReportToHandlers";


### PR DESCRIPTION
This is the code that I am using to reduce payloads on my site.

//src = "url";
//url = "https://www.googletagmanager.com/gtm.js?id=GTM-KB7ZZ5L";
//noop_ = "lodash/noop";
//union, Result = "@wix/wix-code-server";
//matchAny = "@wix/wix-code=client";
//filterByReportToHandlers = "./filterByReportToHandlers";